### PR TITLE
Fixed issues with event connections

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "workbench.iconTheme": "vanilla-icon-theme",
   "robloxLsp.diagnostics.severity": {
     "unused-local": "Error",
     "unused-function": "Error",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "workbench.iconTheme": "vanilla-icon-theme",
   "robloxLsp.diagnostics.severity": {
     "unused-local": "Error",
     "unused-function": "Error",

--- a/src/PluginAction.lua
+++ b/src/PluginAction.lua
@@ -83,8 +83,8 @@ function Component:init()
 	self.action = action
 end
 
-function Component:didUpdate(prev: PluginActionProps, next: PluginActionProps)
-	for eventName, callback in eventProps.changed(prev, next) do
+function Component:didUpdate(oldProps: PluginActionProps)
+	for eventName, callback in eventProps.changed(oldProps, self.props) do
 		if self.events[eventName] ~= nil then
 			self.events[eventName]:Disconnect()
 		end

--- a/src/ToolbarButton.lua
+++ b/src/ToolbarButton.lua
@@ -14,12 +14,12 @@
   })
   ```
 ]=]
-local Roact = require(script.Parent.Parent.Roact)
 local Context = require(script.Parent.Context)
+local Roact = require(script.Parent.Parent.Roact)
 
-local tableUtil = require(script.Parent.Util.tableUtil)
 local eventProps = require(script.Parent.Util.eventProps)
 local makeIcon = require(script.Parent.Util.makeIcon)
+local tableUtil = require(script.Parent.Util.tableUtil)
 
 local Component = Roact.Component:extend("PluginToolbarButton")
 
@@ -86,28 +86,30 @@ function Component:init()
 	self.button = button
 end
 
-function Component:didUpdate(prev: ToolbarButtonProps, next: ToolbarButtonProps)
-	if prev.active ~= next.active then
-		self.button:SetActive(next.active)
+function Component:didUpdate(oldProps: ToolbarButtonProps)
+	local newProps = self.props
+
+	if oldProps.active ~= newProps.active then
+		self.button:SetActive(newProps.active)
 	end
 
-	if prev.enabled ~= next.enabled then
-		self.button.Enabled = next.enabled
+	if oldProps.enabled ~= newProps.enabled then
+		self.button.Enabled = newProps.enabled
 	end
 
-	if prev.alwaysAvailable ~= next.alwaysAvailable then
-		self.button.ClickableWhenViewportHidden = next.alwaysAvailable
+	if oldProps.alwaysAvailable ~= newProps.alwaysAvailable then
+		self.button.ClickableWhenViewportHidden = newProps.alwaysAvailable
 	end
 
-	if prev.icon ~= next.icon then
-		self.button.Icon = makeIcon(next.icon)
+	if oldProps.icon ~= newProps.icon then
+		self.button.Icon = makeIcon(newProps.icon)
 	end
 
-	for eventName, callback in eventProps.changed(prev, next) do
+	for eventName, callback in eventProps.changed(oldProps, newProps) do
 		if self.events[eventName] ~= nil then
 			self.events[eventName]:Disconnect()
 		end
-
+		
 		if callback ~= eventProps.NONE then
 			self.events[eventName] = self.button[eventName]:Connect(function(...)
 				callback(self.button, ...)

--- a/src/Util/eventProps.lua
+++ b/src/Util/eventProps.lua
@@ -1,4 +1,5 @@
 --!strict
+
 --[=[
 	@class eventProps
 	@private
@@ -33,7 +34,7 @@ local function PickEvents(props)
 	end
 
 	for prop, value in props do
-		if type(prop) == "table" and tostring(prop):match("RoactHostEvent(.*)") and prop.name ~= nil then
+		if type(prop) == "table" and tostring(prop):match("^RoactHostEvent%(.*%)$") and prop.name ~= nil then
 			events[prop.name] = value
 		end
 	end
@@ -45,25 +46,28 @@ end
 	@function changed
 	@within eventProps
 
-	@param prev table -- The previous props
-	@param next table -- The new props
+	@param oldProps table -- The old properties
+	@param newProps table -- The new properties
 	@return { [string]: (...any) -> void | userdata }
 
 	Extracts event props that have changed from the given props
 	tables. This is useful for determining which events need to
 	be connected/disconnected.
 ]=]
-local function ChangedEvents(prev, next)
+local function ChangedEvents(oldProps, newProps)
 	local events = {}
 
-	for eventName, callback in PickEvents(next) do
-		if prev[eventName] ~= callback then
+	local oldEvents = PickEvents(oldProps)
+	local newEvents = PickEvents(newProps)
+
+	for eventName, callback in newEvents do
+		if oldEvents[eventName] ~= callback then
 			events[eventName] = callback or NONE
 		end
 	end
 
-	for eventName, _ in PickEvents(prev) do
-		if next[eventName] == nil then
+	for eventName, _ in oldEvents do
+		if newEvents[eventName] == nil then
 			events[eventName] = NONE
 		end
 	end

--- a/src/Widget.lua
+++ b/src/Widget.lua
@@ -27,11 +27,11 @@
   })
   ```
 ]=]
-local Roact = require(script.Parent.Parent.Roact)
 local Context = require(script.Parent.Context)
+local Roact = require(script.Parent.Parent.Roact)
 
-local tableUtil = require(script.Parent.Util.tableUtil)
 local eventProps = require(script.Parent.Util.eventProps)
+local tableUtil = require(script.Parent.Util.tableUtil)
 
 local Component = Roact.Component:extend("PluginWidget")
 
@@ -80,8 +80,8 @@ Component.defaultProps = {
 }
 
 local CUSTOM_EVENTS = {
-	"OnInit",
-	"OnToggle",
+	["OnInit"] = true,
+	["OnToggle"] = true,
 }
 
 function Component:init()
@@ -111,7 +111,7 @@ function Component:init()
 	self.events = {}
 
 	for eventName, callback in eventProps.pick(self.props) do
-		if table.find(CUSTOM_EVENTS, eventName) ~= nil then
+		if CUSTOM_EVENTS[eventName] then
 			continue
 		end
 
@@ -131,21 +131,23 @@ function Component:didMount()
 	end
 end
 
-function Component:didUpdate(prev: WidgetProps, next: WidgetProps)
-	if prev.enabled ~= next.enabled then
-		self.widget.Enabled = next.enabled
+function Component:didUpdate(oldProps: WidgetProps)
+	local newProps = self.props
+
+	if oldProps.enabled ~= newProps.enabled then
+		self.widget.Enabled = newProps.enabled
 	end
 
-	if prev.title ~= next.title then
-		self.widget.Title = next.title
+	if oldProps.title ~= newProps.title then
+		self.widget.Title = newProps.title
 	end
 
-	if prev.zindex ~= next.zindex then
-		self.widget.ZIndexBehavior = next.zindex
+	if oldProps.zindex ~= newProps.zindex then
+		self.widget.ZIndexBehavior = newProps.zindex
 	end
 
-	for eventName, callback in eventProps.pick(next) do
-		if table.find(CUSTOM_EVENTS, eventName) ~= nil then
+	for eventName, callback in eventProps.changed(oldProps, newProps) do
+		if CUSTOM_EVENTS[eventName] then
 			continue
 		end
 


### PR DESCRIPTION
The issue would cause events to be immediately disconnected, due to some issues with how it was detecting event/property changes.

On the components with a `didUpdate` function, it treated the old state value passed in as the new properties.
Strangely enough, this only seemed to get changed after the makeover, so I have no idea why it was even changed.